### PR TITLE
Change bar import to a relative in order to fix tests

### DIFF
--- a/projects/bar/index.js
+++ b/projects/bar/index.js
@@ -1,1 +1,1 @@
-module.exports = require('bar');
+module.exports = require('./bar');


### PR DESCRIPTION
Without this change, tests fail for me, presumably because bar imports from node_modules rather than from the bar.js file:

```
nstoertz@tw-mbp-nstoertz:~/workspace/jest-multi-project-example
$ yarn test
yarn run v1.6.0
$ jest
 FAIL   foo  projects/foo/__tests__/index.test.js
  ● foo › returns bar

    TypeError: bar is not a function

      2 | 
      3 | module.exports = () => {
    > 4 |   return bar();
      5 | };
      6 | 
      
      at Object.<anonymous>.module.exports (index.js:4:10)
      at Object.test (__tests__/index.test.js:5:12)

 FAIL   bar  projects/bar/__tests__/index.js
  ● bar › returns a string

    TypeError: bar is not a function

      3 | describe('bar', () => {
      4 |   test('returns a string', () => {
    > 5 |     expect(bar()).toEqual('this is bar');
      6 |   });
      7 | });
      8 | 
      
      at Object.test (__tests__/index.js:5:12)

Test Suites: 2 failed, 2 total
Tests:       2 failed, 2 total
```

